### PR TITLE
Added autoload comment for MELPA

### DIFF
--- a/ob-sml.el
+++ b/ob-sml.el
@@ -53,6 +53,7 @@
                 (car pair) (org-babel-sml-var-to-sml (cdr pair))))
       vars "\n") "\n" body "\n")))
 
+;;;###autoload
 (defun org-babel-execute:sml (body params)
   "Execute a block of Standard ML code with org-babel.  This function is
 called by `org-babel-execute-src-block'"


### PR DESCRIPTION
Using this, now MELPA generates an autoload declaration so that the file is loaded when you C-c C-c an SML code block in an org file.
