### PR TITLE
Strip '-' printed by SML/NJ when evaling code blocks with leading empty lines

### DIFF
--- a/ob-sml.el
+++ b/ob-sml.el
@@ -78,8 +78,8 @@ called by `org-babel-execute-src-block'"
          (lines (split-string results "\n")))
     (mapconcat #'identity
                (cons
-                ;; remove leading = from SML/NJ multi-line input
-                (replace-regexp-in-string "^[ =]+" "" (car lines))
+                ;; remove leading = and - from SML/NJ multi-line input
+                (replace-regexp-in-string "^[ -]*[ =]+" "" (car lines))
                 ;; drop results of eoe-indicator
                 (butlast (cdr lines) 2))
                "\n")))


### PR DESCRIPTION
Fixes the problem described here https://github.com/swannodette/ob-sml/issues/3
